### PR TITLE
Refactor/unit registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Rename `UnitName` module to `UnitLabel`
 - Rename `UnitName.getName()` to `UnitLabel.getLabel()`
+- The following functions was move from `Units` to `UnitRegistry`: getUnitFromString, isUnit, getStringFromUnit, getUnitsForQuantity, getAllUnits, getAllQuantities
 
 ## [1.0.0] - 2018-05-08
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import * as UnitLabel from "./unit-label";
 import * as UnitInfo from "./unit-info";
 import * as UnitDivide from "./unit-divide";
 import * as UnitTimes from "./unit-times";
+import * as UnitRegistry from "./unit-registry";
 
 export {
   Amount,
@@ -17,5 +18,6 @@ export {
   UnitLabel,
   UnitInfo,
   UnitDivide,
-  UnitTimes
+  UnitTimes,
+  UnitRegistry
 };

--- a/src/unit-info.ts
+++ b/src/unit-info.ts
@@ -1,5 +1,6 @@
 import * as Unit from "./unit";
 import * as Units from "./units";
+import * as UnitRegistry from "./unit-registry";
 import { Quantity } from "./quantity";
 
 export type MeasureSystem = "SI" | "IP";
@@ -13,7 +14,7 @@ export interface UnitInfo {
 const units: { [key: string]: UnitInfo } = {}; //tslint:disable-line
 
 export function getUnitInfo(unit: Unit.Unit<Quantity>): UnitInfo | undefined {
-  return units[Units.getStringFromUnit(unit)];
+  return units[UnitRegistry.getStringFromUnit(unit)];
 }
 
 // The last argument is the corresponding unit which is the closest unit in the other measure system (SI/IP)
@@ -23,7 +24,7 @@ export function addUnit<T extends Quantity>(
   decimalCount: number,
   coUnit?: Unit.Unit<T>
 ): void {
-  units[Units.getStringFromUnit(unit)] = {
+  units[UnitRegistry.getStringFromUnit(unit)] = {
     measureSystem,
     decimalCount,
     coUnit

--- a/src/unit-registry.ts
+++ b/src/unit-registry.ts
@@ -1,0 +1,77 @@
+import * as Unit from "./unit";
+import * as UnitLabel from "./unit-label";
+import { Quantity } from "./quantity";
+
+// const _unitToString: { [key: string]: string } = {}; // tslint:disable-line
+const _stringToUnit: { [key: string]: Unit.Unit } = {}; // tslint:disable-line
+const _quantityToUnits: { [key: string]: Array<Unit.Unit> } = {}; // tslint:disable-line
+
+export function isUnit(unit: string): boolean {
+  return _stringToUnit[unit.trim().toLowerCase()] !== undefined;
+}
+
+export function getUnitFromString<T extends Quantity>(
+  unitString: string,
+  onError?: (unitString: string) => Unit.Unit<T>
+): Unit.Unit<T> {
+  const unit = _stringToUnit[unitString.trim().toLowerCase()];
+  if (unit === undefined) {
+    if (!onError) {
+      throw new Error("Unknown unit " + unitString);
+    } else {
+      return onError(unitString);
+    }
+  }
+  return unit as Unit.Unit<T>;
+}
+
+export function getStringFromUnit(unit: Unit.Unit): string {
+  return unit.name;
+}
+
+export function getQuantityTypeFromString(quantityString: string): string {
+  if (_quantityToUnits[quantityString] === undefined) {
+    throw new Error(`Unknown quantity '${quantityString}'`);
+  }
+  return quantityString;
+}
+
+export function getStringFromQuantityType(quantity: string): string {
+  return quantity;
+}
+
+export function getUnitsForQuantity(quantityType: string): Array<Unit.Unit> {
+  const units = _quantityToUnits[quantityType];
+  if (units === undefined) {
+    throw new Error("Unknown quantity type");
+  }
+  return units;
+}
+
+export function getAllUnits(): Array<Unit.Unit> {
+  const unitsArray = Object.keys(_stringToUnit).map(key => _stringToUnit[key]);
+  return unitsArray;
+}
+
+export function getAllQuantities(): Array<string> {
+  const quantityArray = Object.keys(_quantityToUnits);
+  return quantityArray;
+}
+
+export function registerUnit<T extends Quantity>(
+  unit: Unit.Unit<T>,
+  label: string
+): Unit.Unit<T> {
+  if (label) {
+    UnitLabel.registerLabel(label, unit);
+  }
+  const lowerName = unit.name.toLowerCase();
+  // _unitToString[lowerName] = lowerName;
+  _stringToUnit[lowerName] = unit;
+  if (_quantityToUnits[unit.quantity] === undefined) {
+    _quantityToUnits[unit.quantity] = [];
+  }
+  _quantityToUnits[unit.quantity].push(unit);
+
+  return unit;
+}

--- a/src/units.ts
+++ b/src/units.ts
@@ -1,16 +1,12 @@
 import * as Unit from "./unit";
-import * as UnitLabel from "./unit-label";
 import * as UnitDivide from "./unit-divide";
 import * as UnitTimes from "./unit-times";
 import * as q from "./quantity";
 import { Quantity } from "./quantity";
+import { registerUnit } from "./unit-registry";
 // import * as UnitPow from "./unit-pow";
 
 // tslint:disable variable-name max-line-length max-file-line-count
-
-// const _unitToString: { [key: string]: string } = {}; // tslint:disable-line
-const _stringToUnit: { [key: string]: Unit.Unit } = {}; // tslint:disable-line
-const _quantityToUnits: { [key: string]: Array<Unit.Unit> } = {}; // tslint:disable-line
 
 export const One = registerUnit(Unit.One, " "); // tslint:disable-line
 export const Percent = registerUnit(
@@ -1323,73 +1319,3 @@ export const CubicFeetPerMinutePerSquareRootInchOfWaterColumn = registerUnit(
   ),
   "ft³/min/√in WC"
 );
-
-export function isUnit(unit: string): boolean {
-  return _stringToUnit[unit.trim().toLowerCase()] !== undefined;
-}
-
-export function getUnitFromString<T extends Quantity>(
-  unitString: string,
-  onError?: (unitString: string) => Unit.Unit<T>
-): Unit.Unit<T> {
-  const unit = _stringToUnit[unitString.trim().toLowerCase()];
-  if (unit === undefined) {
-    if (!onError) {
-      throw new Error("Unknown unit " + unitString);
-    } else {
-      return onError(unitString);
-    }
-  }
-  return unit as Unit.Unit<T>;
-}
-
-export function getStringFromUnit(unit: Unit.Unit): string {
-  return unit.name;
-}
-
-export function getQuantityTypeFromString(quantityString: string): string {
-  if (_quantityToUnits[quantityString] === undefined) {
-    throw new Error(`Unknown quantity '${quantityString}'`);
-  }
-  return quantityString;
-}
-
-export function getStringFromQuantityType(quantity: string): string {
-  return quantity;
-}
-
-export function getUnitsForQuantity(quantityType: string): Array<Unit.Unit> {
-  const units = _quantityToUnits[quantityType];
-  if (units === undefined) {
-    throw new Error("Unknown quantity type");
-  }
-  return units;
-}
-
-export function getAllUnits(): Array<Unit.Unit> {
-  const unitsArray = Object.keys(_stringToUnit).map(key => _stringToUnit[key]);
-  return unitsArray;
-}
-
-export function getAllQuantities(): Array<string> {
-  const quantityArray = Object.keys(_quantityToUnits);
-  return quantityArray;
-}
-
-export function registerUnit<T extends Quantity>(
-  unit: Unit.Unit<T>,
-  label: string
-): Unit.Unit<T> {
-  if (label) {
-    UnitLabel.registerLabel(label, unit);
-  }
-  const lowerName = unit.name.toLowerCase();
-  // _unitToString[lowerName] = lowerName;
-  _stringToUnit[lowerName] = unit;
-  if (_quantityToUnits[unit.quantity] === undefined) {
-    _quantityToUnits[unit.quantity] = [];
-  }
-  _quantityToUnits[unit.quantity].push(unit);
-
-  return unit;
-}

--- a/test/units.test.ts
+++ b/test/units.test.ts
@@ -1,5 +1,6 @@
 import * as test from "tape";
 import * as Unit from "../src/unit";
+import * as UnitRegistry from "../src/unit-registry";
 import * as Units from "../src/units";
 // import * as Quantity from "../src/quantity";
 
@@ -10,19 +11,19 @@ import * as Units from "../src/units";
 test("units_test_equals", t => {
   t.test("Base unit One should be equal", st => {
     const unit = Units.One;
-    const unit2 = Units.getUnitFromString("One");
+    const unit2 = UnitRegistry.getUnitFromString("One");
     st.true(Unit.equals(unit, unit2));
     st.end();
   });
   t.test("Base unit One should be equal. Order should not matter", st => {
-    const unit = Units.getStringFromUnit(Unit.One);
-    const unit2 = Units.getStringFromUnit(Unit.One);
+    const unit = UnitRegistry.getStringFromUnit(Unit.One);
+    const unit2 = UnitRegistry.getStringFromUnit(Unit.One);
     st.equal(unit, unit2);
     st.end();
   });
   t.test("Alternate unit Radian should be equal", st => {
     const unit = Units.Radian;
-    const unit2 = Units.getUnitFromString("Radian");
+    const unit2 = UnitRegistry.getUnitFromString("Radian");
     st.true(Unit.equals(unit, unit2));
     st.end();
   });


### PR DESCRIPTION
Move all export that are not `const` declaration of units away from `unit.ts` into `unit-registry.ts`. They are now exported as `UnitRegistry` so this is a breaking change.