### PR TITLE
Move quantity type to each quantity module

### DIFF
--- a/src/quantity.ts
+++ b/src/quantity.ts
@@ -45,7 +45,6 @@ export { MassFlowPerArea } from "./units/mass-flow-per-area";
 export { MomentOfInertia } from "./units/moment-of-inertia";
 export { Power } from "./units/power";
 export { Pressure } from "./units/pressure";
-
 export { RelativeHumidity } from "./units/relative-humidity";
 export { SolidAngle } from "./units/solid-angle";
 export { SoundPowerLevel } from "./units/sound-power-level";

--- a/src/quantity.ts
+++ b/src/quantity.ts
@@ -28,27 +28,24 @@ export { ElectricResistance } from "./units/electric-resistance";
 export { Emission } from "./units/emission";
 export { Energy } from "./units/energy";
 export { Force } from "./units/force";
+export { Frequency } from "./units/frequency";
+export { HeatCapacityRate } from "./units/heat-capacity-rate";
+export { HeatingValue } from "./units/heating-value";
+export { HumidityRatio } from "./units/humidity-ratio";
+export { Illuminance } from "./units/illuminance";
+export { Intensity } from "./units/intensity";
+export { Length } from "./units/length";
+export { LuminousFlux } from "./units/luminous-flux";
+export { LuminousIntensity } from "./units/luminous-intensity";
+export { MagneticFlux } from "./units/magnetic-flux";
+export { MagneticFluxDensity } from "./units/magnetic-flux-density";
+export { Mass } from "./units/mass";
+export { MassFlow } from "./units/mass-flow";
+export { MassFlowPerArea } from "./units/mass-flow-per-area";
+export { MomentOfInertia } from "./units/moment-of-inertia";
+export { Power } from "./units/power";
+export { Pressure } from "./units/pressure";
 
-export type Frequency = "Frequency";
-export type HeatCapacityRate = "HeatCapacityRate";
-export type HeatingValue = "HeatingValue";
-export type HumidityRatio = "HumidityRatio";
-export type Illuminance = "Illuminance";
-export type Intensity = "Intensity";
-export type Length = "Length";
-export type LuminousFlux = "LuminousFlux";
-export type LuminousIntensity = "LuminousIntensity";
-export type MagneticFlux = "MagneticFlux";
-export type MagneticFluxDensity = "MagneticFluxDensity";
-export type Mass = "Mass";
-export type MassFlow = "MassFlow";
-export type MassFlowPerArea = "MassFlowPerArea";
-export type MomentOfInertia = "MomentOfInertia";
-export type Power = "Power";
-export type Pressure = "Pressure";
-export type RadiationDoseAbsorbed = "RadiationDoseAbsorbed";
-export type RadiationDoseEffective = "RadiationDoseEffective";
-export type RadioactiveActivity = "RadioactiveActivity";
 export type RelativeHumidity = "RelativeHumidity";
 export type SolidAngle = "SolidAngle";
 export type SoundPowerLevel = "SoundPowerLevel";
@@ -101,26 +98,23 @@ export type Quantity =
   | Units.Emission
   | Units.Energy
   | Units.Force
-  | Frequency
-  | HeatCapacityRate
-  | HeatingValue
-  | HumidityRatio
-  | Illuminance
-  | Intensity
-  | Length
-  | LuminousFlux
-  | LuminousIntensity
-  | MagneticFlux
-  | MagneticFluxDensity
-  | Mass
-  | MassFlow
-  | MassFlowPerArea
-  | MomentOfInertia
-  | Power
-  | Pressure
-  | RadiationDoseAbsorbed
-  | RadiationDoseEffective
-  | RadioactiveActivity
+  | Units.Frequency
+  | Units.HeatCapacityRate
+  | Units.HeatingValue
+  | Units.HumidityRatio
+  | Units.Illuminance
+  | Units.Intensity
+  | Units.Length
+  | Units.LuminousFlux
+  | Units.LuminousIntensity
+  | Units.MagneticFlux
+  | Units.MagneticFluxDensity
+  | Units.Mass
+  | Units.MassFlow
+  | Units.MassFlowPerArea
+  | Units.MomentOfInertia
+  | Units.Power
+  | Units.Pressure
   | RelativeHumidity
   | SolidAngle
   | SoundPowerLevel

--- a/src/quantity.ts
+++ b/src/quantity.ts
@@ -1,32 +1,34 @@
-import { Acceleration } from "./units/acceleration";
+import * as Units from "./units";
+
 export { Acceleration } from "./units/acceleration";
-export type Alkalinity = "Alkalinity";
-export type AmountOfSubstance = "AmountOfSubstance";
-export type Angle = "Angle";
-export type Area = "Area";
-export type CatalyticActivity = "CatalyticActivity";
-export type DataAmount = "DataAmount";
-export type DeltaDewPointTemperature = "DeltaDewPointTemperature";
-export type DeltaTemperature = "DeltaTemperature";
-export type Density = "Density";
-export type DewPointTemperature = "DewPointTemperature";
-export type Dimensionless = "Dimensionless";
-export type DimensionlessPerEnergy = "DimensionlessPerEnergy";
-export type DimensionlessPerMass = "DimensionlessPerMass";
-export type DimensionlessPerVolume = "DimensionlessPerVolume";
-export type DimensionlessPerDuration = "DimensionlessPerDuration";
-export type Discrete = "Discrete";
-export type Duration = "Duration";
-export type ElectricCapacitance = "ElectricCapacitance";
-export type ElectricCharge = "ElectricCharge";
-export type ElectricConductance = "ElectricConductance";
-export type ElectricInductance = "ElectricInductance";
-export type ElectricCurrent = "ElectricCurrent";
-export type ElectricPotential = "ElectricPotential";
-export type ElectricResistance = "ElectricResistance";
-export type Emission = "Emission";
-export type Energy = "Energy";
-export type Force = "Force";
+export { Alkalinity } from "./units/alkalinity";
+export { AmountOfSubstance } from "./units/amount-of-substance";
+export { Angle } from "./units/angle";
+export { Area } from "./units/area";
+export { CatalyticActivity } from "./units/catalytic-activity";
+export { DataAmount } from "./units/data-amount";
+export { DeltaDewPointTemperature } from "./units/delta-dew-point-temperature";
+export { DeltaTemperature } from "./units/delta-temperature";
+export { Density } from "./units/density";
+export { DewPointTemperature } from "./units/dew-point-temperature";
+export { Dimensionless } from "./units/dimensionless";
+export { DimensionlessPerEnergy } from "./units/dimensionless-per-energy";
+export { DimensionlessPerMass } from "./units/dimensionless-per-mass";
+export { DimensionlessPerVolume } from "./units/dimensionless-per-volume";
+export { DimensionlessPerDuration } from "./units/dimensionless-per-duration";
+export { Discrete } from "./units/discrete";
+export { Duration } from "./units/duration";
+export { ElectricCapacitance } from "./units/electric-capacitance";
+export { ElectricCharge } from "./units/electric-charge";
+export { ElectricConductance } from "./units/electric-conductance";
+export { ElectricInductance } from "./units/electric-inductance";
+export { ElectricCurrent } from "./units/electric-current";
+export { ElectricPotential } from "./units/electric-potential";
+export { ElectricResistance } from "./units/electric-resistance";
+export { Emission } from "./units/emission";
+export { Energy } from "./units/energy";
+export { Force } from "./units/force";
+
 export type Frequency = "Frequency";
 export type HeatCapacityRate = "HeatCapacityRate";
 export type HeatingValue = "HeatingValue";
@@ -71,34 +73,34 @@ export type ThermalTransmittance = "ThermalTransmittance";
 export type ThermalConductivity = "ThermalConductivity";
 
 export type Quantity =
-  | Acceleration
-  | Alkalinity
-  | AmountOfSubstance
-  | Angle
-  | Area
-  | CatalyticActivity
-  | DataAmount
-  | DeltaDewPointTemperature
-  | DeltaTemperature
-  | Density
-  | DewPointTemperature
-  | Dimensionless
-  | DimensionlessPerEnergy
-  | DimensionlessPerMass
-  | DimensionlessPerVolume
-  | DimensionlessPerDuration
-  | Discrete
-  | Duration
-  | ElectricCapacitance
-  | ElectricCharge
-  | ElectricConductance
-  | ElectricInductance
-  | ElectricCurrent
-  | ElectricPotential
-  | ElectricResistance
-  | Emission
-  | Energy
-  | Force
+  | Units.Acceleration
+  | Units.Alkalinity
+  | Units.AmountOfSubstance
+  | Units.Angle
+  | Units.Area
+  | Units.CatalyticActivity
+  | Units.DataAmount
+  | Units.DeltaDewPointTemperature
+  | Units.DeltaTemperature
+  | Units.Density
+  | Units.DewPointTemperature
+  | Units.Dimensionless
+  | Units.DimensionlessPerEnergy
+  | Units.DimensionlessPerMass
+  | Units.DimensionlessPerVolume
+  | Units.DimensionlessPerDuration
+  | Units.Discrete
+  | Units.Duration
+  | Units.ElectricCapacitance
+  | Units.ElectricCharge
+  | Units.ElectricConductance
+  | Units.ElectricInductance
+  | Units.ElectricCurrent
+  | Units.ElectricPotential
+  | Units.ElectricResistance
+  | Units.Emission
+  | Units.Energy
+  | Units.Force
   | Frequency
   | HeatCapacityRate
   | HeatingValue

--- a/src/quantity.ts
+++ b/src/quantity.ts
@@ -46,28 +46,30 @@ export { MomentOfInertia } from "./units/moment-of-inertia";
 export { Power } from "./units/power";
 export { Pressure } from "./units/pressure";
 
-export type RelativeHumidity = "RelativeHumidity";
-export type SolidAngle = "SolidAngle";
-export type SoundPowerLevel = "SoundPowerLevel";
-export type SoundPressureLevel = "SoundPressureLevel";
-export type SpecificEnthalpy = "SpecificEnthalpy";
-export type SpecificFanPower = "SpecificFanPower";
-export type SpecificHeatCapacity = "SpecificHeatCapacity";
-export type SquareRootPressure = "SquareRootPressure";
-export type Temperature = "Temperature";
-export type Text = "Text";
-export type Velocity = "Velocity";
-export type Viscosity = "Viscosity";
-export type Volume = "Volume";
-export type VolumeFlow = "VolumeFlow";
-export type VolumeFlowPerArea = "VolumeFlowPerArea";
-export type VolumeFlowPerPower = "VolumeFlowPerPower";
-export type VolumeFlowPerSquareRootPressure = "VolumeFlowPerSquareRootPressure";
-export type WaterHardness = "WaterHardness";
-export type WaterUseEfficiency = "WaterUseEfficiency";
-export type WetTemperature = "WetTemperature";
-export type ThermalTransmittance = "ThermalTransmittance";
-export type ThermalConductivity = "ThermalConductivity";
+export { RelativeHumidity } from "./units/relative-humidity";
+export { SolidAngle } from "./units/solid-angle";
+export { SoundPowerLevel } from "./units/sound-power-level";
+export { SoundPressureLevel } from "./units/sound-pressure-level";
+export { SpecificEnthalpy } from "./units/specific-enthalpy";
+export { SpecificFanPower } from "./units/specific-fan-power";
+export { SpecificHeatCapacity } from "./units/specific-heat-capacity";
+export { SquareRootPressure } from "./units/square-root-pressure";
+export { Temperature } from "./units/temperature";
+export { Text } from "./units/text";
+export { Velocity } from "./units/velocity";
+export { Viscosity } from "./units/viscosity";
+export { Volume } from "./units/volume";
+export { VolumeFlow } from "./units/volume-flow";
+export { VolumeFlowPerArea } from "./units/volume-flow-per-area";
+export { VolumeFlowPerPower } from "./units/volume-flow-per-power";
+export {
+  VolumeFlowPerSquareRootPressure
+} from "./units/volume-flow-per-square-root-pressure";
+export { WaterHardness } from "./units/water-hardness";
+export { WaterUseEfficiency } from "./units/water-use-efficiency";
+export { WetTemperature } from "./units/wet-temperature";
+export { ThermalTransmittance } from "./units/thermal-transmittance";
+export { ThermalConductivity } from "./units/thermal-conductivity";
 
 export type Quantity =
   | Units.Acceleration
@@ -115,25 +117,25 @@ export type Quantity =
   | Units.MomentOfInertia
   | Units.Power
   | Units.Pressure
-  | RelativeHumidity
-  | SolidAngle
-  | SoundPowerLevel
-  | SoundPressureLevel
-  | SpecificEnthalpy
-  | SpecificFanPower
-  | SpecificHeatCapacity
-  | SquareRootPressure
-  | Temperature
-  | Text
-  | Velocity
-  | Viscosity
-  | Volume
-  | VolumeFlow
-  | VolumeFlowPerArea
-  | VolumeFlowPerPower
-  | VolumeFlowPerSquareRootPressure
-  | WaterHardness
-  | WaterUseEfficiency
-  | WetTemperature
-  | ThermalTransmittance
-  | ThermalConductivity;
+  | Units.RelativeHumidity
+  | Units.SolidAngle
+  | Units.SoundPowerLevel
+  | Units.SoundPressureLevel
+  | Units.SpecificEnthalpy
+  | Units.SpecificFanPower
+  | Units.SpecificHeatCapacity
+  | Units.SquareRootPressure
+  | Units.Temperature
+  | Units.Text
+  | Units.Velocity
+  | Units.Viscosity
+  | Units.Volume
+  | Units.VolumeFlow
+  | Units.VolumeFlowPerArea
+  | Units.VolumeFlowPerPower
+  | Units.VolumeFlowPerSquareRootPressure
+  | Units.WaterHardness
+  | Units.WaterUseEfficiency
+  | Units.WetTemperature
+  | Units.ThermalTransmittance
+  | Units.ThermalConductivity;

--- a/src/quantity.ts
+++ b/src/quantity.ts
@@ -1,4 +1,5 @@
-export type Acceleration = "Acceleration";
+import { Acceleration } from "./units/acceleration";
+export { Acceleration } from "./units/acceleration";
 export type Alkalinity = "Alkalinity";
 export type AmountOfSubstance = "AmountOfSubstance";
 export type Angle = "Angle";

--- a/src/units-format/index.ts
+++ b/src/units-format/index.ts
@@ -62,3 +62,5 @@ export * from "./intensity-format";
 export * from "./power-format";
 export * from "./specific-fan-power-format";
 export * from "./temperature-format";
+export * from "./data-amount-format";
+export * from "./dew-point-temperature-format";

--- a/src/units/acceleration.ts
+++ b/src/units/acceleration.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { MeterPerSecond } from "./velocity";
 import { Second } from "./base-units";
 
+export type Acceleration = "Acceleration";
+
 // tslint:disable:variable-name
 
 /** The metric unit for acceleration quantities ( <code>m/s²</code> ). */

--- a/src/units/alkalinity.ts
+++ b/src/units/alkalinity.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type Alkalinity = "Alkalinity";
+
 // tslint:disable:variable-name
 
 // Alkalinity

--- a/src/units/amount-of-substance.ts
+++ b/src/units/amount-of-substance.ts
@@ -1,0 +1,1 @@
+export type AmountOfSubstance = "AmountOfSubstance";

--- a/src/units/angle.ts
+++ b/src/units/angle.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type Angle = "Angle";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/area.ts
+++ b/src/units/area.ts
@@ -2,6 +2,8 @@ import { Squared } from "../unit-prefix";
 import { Meter } from "./base-units";
 import { Inch, Foot, Millimeter, CentiMeter, Decimeter } from "./length";
 
+export type Area = "Area";
+
 // tslint:disable:variable-name
 
 /** The metric unit for area quantities ( <code>m²</code> ). */

--- a/src/units/catalytic-activity.ts
+++ b/src/units/catalytic-activity.ts
@@ -1,6 +1,8 @@
 import * as UnitDivide from "../unit-divide";
 import { Second, Mole } from "./base-units";
 
+export type CatalyticActivity = "CatalyticActivity";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/data-amount.ts
+++ b/src/units/data-amount.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type DataAmount = "DataAmount";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/delta-dew-point-temperature.ts
+++ b/src/units/delta-dew-point-temperature.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type DeltaDewPointTemperature = "DeltaDewPointTemperature";
+
 // tslint:disable:variable-name
 
 // DeltaDewPointTemperature

--- a/src/units/delta-temperature.ts
+++ b/src/units/delta-temperature.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type DeltaTemperature = "DeltaTemperature";
+
 // tslint:disable:variable-name
 
 // Delta temperature

--- a/src/units/density.ts
+++ b/src/units/density.ts
@@ -3,6 +3,8 @@ import { Kilogram } from "./base-units";
 import { CubicMeter, CubicCentiMeter, CubicFeet } from "./volume";
 import { Gram, Slug, PoundLb } from "./mass";
 
+export type Density = "Density";
+
 // tslint:disable:variable-name
 
 // Density

--- a/src/units/dew-point-temperature.ts
+++ b/src/units/dew-point-temperature.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type DewPointTemperature = "DewPointTemperature";
+
 // tslint:disable:variable-name
 
 export const CelsiusDewPoint = Unit.createBase(

--- a/src/units/dimensionless-per-duration.ts
+++ b/src/units/dimensionless-per-duration.ts
@@ -3,6 +3,8 @@ import { Second } from "./base-units";
 import { One } from "../unit";
 import { Hour } from "./duration";
 
+export type DimensionlessPerDuration = "DimensionlessPerDuration";
+
 // tslint:disable:variable-name
 
 // Per Duration

--- a/src/units/dimensionless-per-energy.ts
+++ b/src/units/dimensionless-per-energy.ts
@@ -3,6 +3,8 @@ import { One } from "../unit";
 import { Joule, Megajoule, Kilojoule, Therm, MegaBtu, Btu } from "./energy";
 import { KiloWattHour } from "./energy2";
 
+export type DimensionlessPerEnergy = "DimensionlessPerEnergy";
+
 // tslint:disable:variable-name
 
 /// http://www.wolframalpha.com/input/?i=BTU and select 'Show exact conversions'

--- a/src/units/dimensionless-per-mass.ts
+++ b/src/units/dimensionless-per-mass.ts
@@ -3,6 +3,8 @@ import { Kilogram } from "./base-units";
 import { One } from "../unit";
 import { PoundLb } from "./mass";
 
+export type DimensionlessPerMass = "DimensionlessPerMass";
+
 // tslint:disable:variable-name
 
 // Per mass

--- a/src/units/dimensionless-per-volume.ts
+++ b/src/units/dimensionless-per-volume.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { Liter, CubicMeter, Gallon, HundredCubicFeet } from "./volume";
 import { One } from "../unit";
 
+export type DimensionlessPerVolume = "DimensionlessPerVolume";
+
 // tslint:disable:variable-name
 
 // Per Volume

--- a/src/units/dimensionless.ts
+++ b/src/units/dimensionless.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type Dimensionless = "Dimensionless";
+
 // tslint:disable:variable-name
 
 export const One = Unit.One;

--- a/src/units/discrete.ts
+++ b/src/units/discrete.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type Discrete = "Discrete";
+
 // tslint:disable:variable-name
 
 // Discrete

--- a/src/units/duration.ts
+++ b/src/units/duration.ts
@@ -2,6 +2,8 @@ import * as Unit from "../unit";
 import { Second } from "./base-units";
 import { Milli } from "../unit-prefix";
 
+export type Duration = "Duration";
+
 // tslint:disable:variable-name
 
 // Duration / Time

--- a/src/units/electric-capacitance.ts
+++ b/src/units/electric-capacitance.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { Coulomb } from "./electric-charge";
 import { Volt } from "./electric-potential";
 
+export type ElectricCapacitance = "ElectricCapacitance";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/electric-charge.ts
+++ b/src/units/electric-charge.ts
@@ -1,6 +1,8 @@
 import * as UnitTimes from "../unit-times";
 import { Second, Ampere } from "./base-units";
 
+export type ElectricCharge = "ElectricCharge";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/electric-conductance.ts
+++ b/src/units/electric-conductance.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { Ampere } from "./base-units";
 import { Volt } from "./electric-potential";
 
+export type ElectricConductance = "ElectricConductance";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/electric-current.ts
+++ b/src/units/electric-current.ts
@@ -1,6 +1,8 @@
 import { Ampere } from "./base-units";
 import { Milli } from "../unit-prefix";
 
+export type ElectricCurrent = "ElectricCurrent";
+
 // tslint:disable:variable-name
 
 // Electric current

--- a/src/units/electric-inductance.ts
+++ b/src/units/electric-inductance.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { Ampere } from "./base-units";
 import { Weber } from "./magnetic-flux";
 
+export type ElectricInductance = "ElectricInductance";
+
 // tslint:disable:variable-name
 
 export const Henry = UnitDivide.magneticFluxByElectricalCurrent(

--- a/src/units/electric-potential.ts
+++ b/src/units/electric-potential.ts
@@ -3,6 +3,8 @@ import { Ampere } from "./base-units";
 import { Watt } from "./power";
 import { Milli, Kilo } from "../unit-prefix";
 
+export type ElectricPotential = "ElectricPotential";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/electric-resistance.ts
+++ b/src/units/electric-resistance.ts
@@ -3,6 +3,8 @@ import { Ampere } from "./base-units";
 import { Volt } from "./electric-potential";
 import { Kilo } from "../unit-prefix";
 
+export type ElectricResistance = "ElectricResistance";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/emission.ts
+++ b/src/units/emission.ts
@@ -3,6 +3,8 @@ import { KiloWattHour } from "./energy2";
 import { Gram, PoundLb } from "./mass";
 import { massByEnergy } from "../unit-divide";
 
+export type Emission = "Emission";
+
 // tslint:disable:variable-name
 
 // Emission

--- a/src/units/energy.ts
+++ b/src/units/energy.ts
@@ -4,6 +4,8 @@ import { Meter } from "./base-units";
 import { Newton } from "./force";
 import { Kilo, Mega } from "../unit-prefix";
 
+export type Energy = "Energy";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/force.ts
+++ b/src/units/force.ts
@@ -3,6 +3,8 @@ import * as Unit from "../unit";
 import { Kilogram } from "./base-units";
 import { MeterPerSquareSecond } from "./acceleration";
 
+export type Force = "Force";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/frequency.ts
+++ b/src/units/frequency.ts
@@ -3,6 +3,8 @@ import { Second } from "./base-units";
 import { One } from "./dimensionless";
 import { Minute, Hour } from "./duration";
 
+export type Frequency = "Frequency";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/heat-capacity-rate.ts
+++ b/src/units/heat-capacity-rate.ts
@@ -3,6 +3,8 @@ import { Kelvin } from "./base-units";
 import { KiloWatt } from "./power";
 import { Celsius } from "./temperature";
 
+export type HeatCapacityRate = "HeatCapacityRate";
+
 // tslint:disable:variable-name
 
 // Heat Capacity Rate

--- a/src/units/heating-value.ts
+++ b/src/units/heating-value.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { KiloWattHour } from "./energy2";
 import { CubicMeter } from "./volume";
 
+export type HeatingValue = "HeatingValue";
+
 // tslint:disable:variable-name
 
 // Energy per volume

--- a/src/units/humidity-ratio.ts
+++ b/src/units/humidity-ratio.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { Kilogram } from "./base-units";
 import { Gram, PoundLb, Grain } from "./mass";
 
+export type HumidityRatio = "HumidityRatio";
+
 // tslint:disable:variable-name
 
 // Humidity

--- a/src/units/illuminance.ts
+++ b/src/units/illuminance.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { Lumen } from "./luminous-flux";
 import { SquareMeter } from "./area";
 
+export type Illuminance = "Illuminance";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/index.ts
+++ b/src/units/index.ts
@@ -63,3 +63,6 @@ export * from "./intensity";
 export * from "./power";
 export * from "./specific-fan-power";
 export * from "./temperature";
+export * from "./amount-of-substance";
+export * from "./data-amount";
+export * from "./dew-point-temperature";

--- a/src/units/index.ts
+++ b/src/units/index.ts
@@ -66,3 +66,4 @@ export * from "./temperature";
 export * from "./amount-of-substance";
 export * from "./data-amount";
 export * from "./dew-point-temperature";
+export * from "./luminous-intensity";

--- a/src/units/intensity.ts
+++ b/src/units/intensity.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { Watt } from "./power";
 import { SquareMeter } from "./area";
 
+export type Intensity = "Intensity";
+
 // tslint:disable:variable-name
 
 // Intensity

--- a/src/units/length.ts
+++ b/src/units/length.ts
@@ -7,6 +7,8 @@ import { Meter } from "./base-units";
 /** Equivalent to <code>KILO(METER)</code>. */
 export const Kilometer = Kilo("Kilometer", Meter);
 
+export type Length = "Length";
+
 /** Equivalent to <code>CENTI(METRE)</code>. */
 export const CentiMeter = Centi("CentiMeter", Meter);
 

--- a/src/units/luminous-flux.ts
+++ b/src/units/luminous-flux.ts
@@ -2,6 +2,8 @@ import * as UnitTimes from "../unit-times";
 import { Candela } from "./base-units";
 import { Steradian } from "./solid-angle";
 
+export type LuminousFlux = "LuminousFlux";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/luminous-intensity.ts
+++ b/src/units/luminous-intensity.ts
@@ -1,0 +1,1 @@
+export type LuminousIntensity = "LuminousIntensity";

--- a/src/units/magnetic-flux-density.ts
+++ b/src/units/magnetic-flux-density.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { Weber } from "./magnetic-flux";
 import { SquareMeter } from "./area";
 
+export type MagneticFluxDensity = "MagneticFluxDensity";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/magnetic-flux.ts
+++ b/src/units/magnetic-flux.ts
@@ -2,6 +2,8 @@ import * as UnitTimes from "../unit-times";
 import { Second } from "./base-units";
 import { Volt } from "./electric-potential";
 
+export type MagneticFlux = "MagneticFlux";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/mass-flow-per-area.ts
+++ b/src/units/mass-flow-per-area.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { KilogramPerSecond } from "./mass-flow";
 import { SquareMeter } from "./area";
 
+export type MassFlowPerArea = "MassFlowPerArea";
+
 // tslint:disable:variable-name
 
 export const KilogramPerSquareMeterSecond = UnitDivide.massFlowByArea(

--- a/src/units/mass-flow.ts
+++ b/src/units/mass-flow.ts
@@ -4,6 +4,8 @@ import { Second, Kilogram } from "./base-units";
 import { Gram, Slug, PoundLb, Grain } from "./mass";
 import { Hour } from "./duration";
 
+export type MassFlow = "MassFlow";
+
 // tslint:disable:variable-name
 
 // MassFlow

--- a/src/units/mass.ts
+++ b/src/units/mass.ts
@@ -2,6 +2,8 @@ import * as Unit from "../unit";
 import { Kilogram } from "./base-units";
 import { Milli } from "../unit-prefix";
 
+export type Mass = "Mass";
+
 // tslint:disable:variable-name
 
 /** The derived unit for mass quantities ( <code>g</code> ).

--- a/src/units/moment-of-inertia.ts
+++ b/src/units/moment-of-inertia.ts
@@ -2,6 +2,8 @@ import * as UnitTimes from "../unit-times";
 import { SquareMeter } from "./area";
 import { Kilogram } from "./base-units";
 
+export type MomentOfInertia = "MomentOfInertia";
+
 // tslint:disable:variable-name
 
 /// Moment of inertia

--- a/src/units/power.ts
+++ b/src/units/power.ts
@@ -4,6 +4,8 @@ import { Second } from "./base-units";
 import { Joule } from "./energy";
 import { Kilo, Mega, Giga } from "../unit-prefix";
 
+export type Power = "Power";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/pressure.ts
+++ b/src/units/pressure.ts
@@ -4,6 +4,8 @@ import { Newton } from "./force";
 import { SquareMeter } from "./area";
 import { Kilo, Hecto, Deci, Milli } from "../unit-prefix";
 
+export type Pressure = "Pressure";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/relative-humidity.ts
+++ b/src/units/relative-humidity.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type RelativeHumidity = "RelativeHumidity";
+
 // tslint:disable:variable-name
 
 export const HumidityFactor = Unit.createBase(

--- a/src/units/solid-angle.ts
+++ b/src/units/solid-angle.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type SolidAngle = "SolidAngle";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/sound-power-level.ts
+++ b/src/units/sound-power-level.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type SoundPowerLevel = "SoundPowerLevel";
+
 // tslint:disable:variable-name
 
 // Sound power level

--- a/src/units/sound-pressure-level.ts
+++ b/src/units/sound-pressure-level.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type SoundPressureLevel = "SoundPressureLevel";
+
 // tslint:disable:variable-name
 
 // Sound pressure level

--- a/src/units/specific-enthalpy.ts
+++ b/src/units/specific-enthalpy.ts
@@ -4,6 +4,8 @@ import { Kilogram } from "./base-units";
 import { Joule, Kilojoule } from "./energy";
 import { KiloWattHour } from "./energy2";
 
+export type SpecificEnthalpy = "SpecificEnthalpy";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/specific-fan-power.ts
+++ b/src/units/specific-fan-power.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { KiloWatt, Watt } from "./power";
 import { CubicMeterPerSecond, CubicFeetPerMinute } from "./volume-flow";
 
+export type SpecificFanPower = "SpecificFanPower";
+
 // tslint:disable:variable-name
 
 // Specific Fan Power

--- a/src/units/specific-heat-capacity.ts
+++ b/src/units/specific-heat-capacity.ts
@@ -3,6 +3,8 @@ import { Kelvin } from "./base-units";
 import { Celsius } from "./temperature";
 import { KilojoulePerKilogram } from "./specific-enthalpy";
 
+export type SpecificHeatCapacity = "SpecificHeatCapacity";
+
 // tslint:disable:variable-name
 
 // Specific heat capacity of air at constant pressure (kJ/kg°C, kWs/kgK, Btu/lb°F)

--- a/src/units/square-root-pressure.ts
+++ b/src/units/square-root-pressure.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type SquareRootPressure = "SquareRootPressure";
+
 // tslint:disable:variable-name
 
 //SquareRootPressure

--- a/src/units/temperature.ts
+++ b/src/units/temperature.ts
@@ -1,6 +1,8 @@
 import * as Unit from "../unit";
 import { Kelvin } from "./base-units";
 
+export type Temperature = "Temperature";
+
 // tslint:disable:variable-name
 
 /**

--- a/src/units/text.ts
+++ b/src/units/text.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type Text = "Text";
+
 // tslint:disable:variable-name
 
 // Text

--- a/src/units/thermal-conductivity.ts
+++ b/src/units/thermal-conductivity.ts
@@ -4,6 +4,8 @@ import { Meter } from "./base-units";
 import { DeltaCelsius } from "./delta-temperature";
 import { Foot } from "./length";
 
+export type ThermalConductivity = "ThermalConductivity";
+
 // tslint:disable:variable-name
 
 // Thermal conductivity

--- a/src/units/thermal-transmittance.ts
+++ b/src/units/thermal-transmittance.ts
@@ -3,6 +3,8 @@ import { Watt, BtuPerHour } from "./power";
 import { SquareMeter, SquareFeet } from "./area";
 import { DeltaCelsius, DeltaFahrenheit } from "./delta-temperature";
 
+export type ThermalTransmittance = "ThermalTransmittance";
+
 // tslint:disable:variable-name
 
 // Thermal Transmittance

--- a/src/units/velocity.ts
+++ b/src/units/velocity.ts
@@ -3,6 +3,8 @@ import { Meter, Second } from "./base-units";
 import { Foot, Mile, Kilometer } from "./length";
 import { Minute, Hour } from "./duration";
 
+export type Velocity = "Velocity";
+
 // tslint:disable:variable-name
 
 /** The metric unit for velocity quantities ( <code>m/s</code> ). */

--- a/src/units/viscosity.ts
+++ b/src/units/viscosity.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type Viscosity = "Viscosity";
+
 // tslint:disable:variable-name
 
 // Viscosity

--- a/src/units/volume-flow-per-area.ts
+++ b/src/units/volume-flow-per-area.ts
@@ -6,6 +6,8 @@ import {
 } from "./volume-flow";
 import { SquareMeter, SquareFeet } from "./area";
 
+export type VolumeFlowPerArea = "VolumeFlowPerArea";
+
 // tslint:disable:variable-name
 
 // VolumeFlowPerArea

--- a/src/units/volume-flow-per-power.ts
+++ b/src/units/volume-flow-per-power.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { GallonsPerMinute, LiterPerSecond } from "./volume-flow";
 import { TonCooling, KiloWatt } from "./power";
 
+export type VolumeFlowPerPower = "VolumeFlowPerPower";
+
 // tslint:disable:variable-name
 
 // Volume flow per cooling power

--- a/src/units/volume-flow-per-square-root-pressure.ts
+++ b/src/units/volume-flow-per-square-root-pressure.ts
@@ -5,6 +5,8 @@ import {
   SquareRootInchOfWaterColumn
 } from "./square-root-pressure";
 
+export type VolumeFlowPerSquareRootPressure = "VolumeFlowPerSquareRootPressure";
+
 // tslint:disable:variable-name
 
 //VolumeFlowPerSquareRootPressure

--- a/src/units/volume-flow.ts
+++ b/src/units/volume-flow.ts
@@ -9,6 +9,8 @@ import {
 } from "./volume";
 import { Hour, Minute } from "./duration";
 
+export type VolumeFlow = "VolumeFlow";
+
 // tslint:disable:variable-name
 
 // VolumeFlow

--- a/src/units/volume.ts
+++ b/src/units/volume.ts
@@ -3,6 +3,8 @@ import { Cubed, Milli } from "../unit-prefix";
 import { Meter } from "./base-units";
 import { CentiMeter, Inch, Foot } from "./length";
 
+export type Volume = "Volume";
+
 // tslint:disable:variable-name
 
 /** The metric unit for volume quantities ( <code>m³</code> ). */

--- a/src/units/water-hardness.ts
+++ b/src/units/water-hardness.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type WaterHardness = "WaterHardness";
+
 // tslint:disable:variable-name
 
 // Water hardness

--- a/src/units/water-use-efficiency.ts
+++ b/src/units/water-use-efficiency.ts
@@ -2,6 +2,8 @@ import * as UnitDivide from "../unit-divide";
 import { Liter } from "./volume";
 import { KiloWattHour } from "./energy2";
 
+export type WaterUseEfficiency = "WaterUseEfficiency";
+
 // tslint:disable:variable-name
 
 /// Water use efficiency

--- a/src/units/wet-temperature.ts
+++ b/src/units/wet-temperature.ts
@@ -1,5 +1,7 @@
 import * as Unit from "../unit";
 
+export type WetTemperature = "WetTemperature";
+
 // tslint:disable:variable-name
 
 export const CelsiusWet = Unit.createBase(


### PR DESCRIPTION
This PR moves the declaration of each quantity type to the module/file where the units for that quantity is declared. This makes each such module self-sufficent instead of spreading the declarations in two files.