### PR TITLE
Include typescript source in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-# ignore everything
-*/**
-
-# except
-!lib-cjs/**/*
-!lib-esm/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Include typescript source from `src/` in published npm package. See PR [#XX](https://github.com/dividab/uom/pull/XX) for more info.
+- Include typescript source from `src/` in published npm package. See PR [#50](https://github.com/dividab/uom/pull/50) for more info.
 
 ## [v4.0.0](https://github.com/dividab/uom/compare/v3.0.0...v4.0.0) - 2020-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/dividab/uom/compare/v4.1.0...master)
 
-## [v4.1.0](https://github.com/dividab/uom/compare/v4.0.0...v4.1.0) - 2020-03-29
-
 ### Added
 
 - Include typescript source from `src/` in published npm package. See PR [#50](https://github.com/dividab/uom/pull/50) for more info.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/dividab/uom/compare/v4.0.0...master)
+## [Unreleased](https://github.com/dividab/uom/compare/v4.1.0...master)
+
+## [v4.1.0](https://github.com/dividab/uom/compare/v4.0.0...v4.1.0) - 2020-03-29
+
+### Added
+
+- Include typescript source from `src/` in published npm package. See PR [#XX](https://github.com/dividab/uom/pull/XX) for more info.
 
 ## [v4.0.0](https://github.com/dividab/uom/compare/v3.0.0...v4.0.0) - 2020-01-09
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,15 @@
   "author": "jonas.kello@divid.se",
   "repository": "https://github.com/dividab/uom",
   "license": "MIT",
+  "files": [
+    "/lib-cjs",
+    "/lib-esm",
+    "/src",
+    "package.json",
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md"
+  ],
   "devDependencies": {
     "@types/jest": "^24.0.18",
     "@types/node": "^12.7.11",


### PR DESCRIPTION
This PR will include the typescript sources in src/ in the published npm package. We were already including *.map files but when eg. webpack tried to load them the referenced typescript files in src/ were not found so webpack emits a warning.

The choice is either to make a special production build without source maps and publish the *.js files without any sourcemap refrences, or include everything in the npm package. My reasoning here is that if we include everything it will be easier to get god stack traces and debug.