### PR TITLE
Add unit lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/dividab/uom/compare/v4.1.0...master)
+## [Unreleased](https://github.com/dividab/uom/compare/v5.0.0...master)
+
+## [v5.0.0](https://github.com/dividab/uom/compare/v4.1.0...v5.0.0) - 2020-10-08
+
+### Changed
+- The consumer of the package is responsible for sending in a unit lookup function. See PR [#51](https://github.com/dividab/uom/pull/51).
 
 ## [v4.1.0](https://github.com/dividab/uom/compare/v4.0.0...v4.1.0) - 2020-03-29
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -11,9 +11,9 @@ import * as Amount from "./amount";
  */
 export function stringToUnit<T>(
   unitString: string,
-  units: Unit.UnitMap
+  unitLookup: Unit.UnitLookup
 ): Unit.Unit<T> | undefined {
-  return units[unitString] as Unit.Unit<T>;
+  return unitLookup(unitString) as Unit.Unit<T>;
 }
 
 /**
@@ -43,11 +43,11 @@ export function amountToString(amount: Amount.Amount<unknown>): string {
  */
 export function stringToAmount(
   amountString: string,
-  units: Unit.UnitMap
+  unitLookup: Unit.UnitLookup
 ): Amount.Amount<unknown> | undefined {
   const parts = amountString.split(":");
   const value = parseFloat(parts[0]);
-  const unit = stringToUnit(parts[1], units);
+  const unit = stringToUnit(parts[1], unitLookup);
   if (!unit) {
     return undefined;
   }

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -9,6 +9,8 @@ export interface Unit<TQuantityName> {
   readonly unitInfo: UnitInfo<TQuantityName>;
 }
 
+export type UnitLookup = (unitString: string) => Unit<unknown> | undefined;
+
 export type UnitMap = {
   readonly [key: string]: Unit<unknown>;
 };

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -1,13 +1,29 @@
 // import { Units } from "../src/all-units";
 import { Serialize, BaseUnits } from "../src";
+import { UnitMap } from "../src/unit";
 
+const baseUnitsLower = Object.keys(BaseUnits).reduce(
+  (soFar, current) => {
+    return {
+      ...soFar,
+      [current.toLowerCase()]: (BaseUnits as UnitMap)[current]
+    };
+  },
+  {} as UnitMap
+);
 describe("serialize_test", () => {
   test("For Kelvin should return BaseUnits.Kelvin", () => {
-    const unit = Serialize.stringToUnit("Kelvin", BaseUnits);
+    const unit = Serialize.stringToUnit(
+      "Kelvin",
+      unitString => (BaseUnits as UnitMap)[unitString]
+    );
     expect(unit).toEqual(BaseUnits.Kelvin);
   });
   test("For kelvin should return BaseUnits.Kelvin", () => {
-    const unit = Serialize.stringToUnit("Kelvin", BaseUnits);
+    const unit = Serialize.stringToUnit(
+      "kelvin",
+      unitString => baseUnitsLower[unitString]
+    );
     expect(unit).toEqual(BaseUnits.Kelvin);
   });
 });


### PR DESCRIPTION
In v4.0.0 we addressed a performance issue with looking up units. But the feature for case insensitive units was removed. This PR creates a unitLookup function instead which takes unitString as a parameter and returns the matching unit. In this way we can still have case insesitve units and perfomance. It will be up to the consumer to implement the lookup